### PR TITLE
Debian packaging: remove dependency on 'apg'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -63,7 +63,6 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          accountsservice,
-         apg,
          colord (>= 0.1.30),
          desktop-file-utils,
          budgie-control-center-data,


### PR DESCRIPTION
GNOME upstream [removed support for `apg`](https://gitlab.gnome.org/GNOME/gnome-control-center/-/commit/810f29b6cee271cf784aef6478a1952a5ee60b8e) in Y2012.

Additionally, [`apg` no longer has an active/contactable upstream](https://salsa.debian.org/debian/apg/-/commit/8622b7aa80e5c5c4156296b14472f90c348e0c52), and so reducing dependence on it may make sense generally.

Closes [#1104261](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1104261).